### PR TITLE
Fix crash in queue processing by adding nil check during termination

### DIFF
--- a/rotate/logger.go
+++ b/rotate/logger.go
@@ -141,9 +141,8 @@ func (l *logger) Log(message gen.MessageLog) {
 }
 
 func (l *logger) Terminate() {
-	atomic.StoreInt32(&l.state, 2)
-	l.queue.Push(nil)
-	if atomic.CompareAndSwapInt32(&l.state, 0, 1) == true {
+	if prev := atomic.SwapInt32(&l.state, 2); prev == 0 {
+		//handle the queue in case something is left there
 		go l.write()
 	}
 }
@@ -158,7 +157,7 @@ next:
 
 	for {
 		m, ok := l.queue.Pop()
-		if !ok || m == nil {
+		if ok == false {
 			break
 		}
 		message := m.(gen.MessageLog)

--- a/rotate/logger.go
+++ b/rotate/logger.go
@@ -158,7 +158,7 @@ next:
 
 	for {
 		m, ok := l.queue.Pop()
-		if ok == false {
+		if !ok || m == nil {
 			break
 		}
 		message := m.(gen.MessageLog)


### PR DESCRIPTION
This PR fixes a crash that occurs when terminating the queue processing logic.
When Terminate() is called, a nil value is pushed to the queue (l.queue.Push(nil)), but the consumer (l.write()) did not handle nil entries, leading to a runtime panic.

Changes

Added a nil check in l.write() to skip processing nil queue entries.